### PR TITLE
Adding to the html documentation the ribbon 'Fork me on GitHub'

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,8 @@
+{% extends '!layout.html' %}
+{% block document %}
+{{super()}}
+    <a href="https://github.com/uibcdf/openpharmacophore">
+        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub">
+    </a>
+{% endblock %}
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,6 +161,8 @@ html_css_files = [
 #
 # html_sidebars = {}
 
+# Removing "view page source" from the top-right corner
+html_show_sourcelink = False
 
 # -- Options for HTMLHelp output ---------------------------------------------
 


### PR DESCRIPTION
## Description
The clickable sentence 'View page source' in the right top corner of the HTML documentation was replaced by a black ribbon saying 'Fork me on GitHub'.

  - A new file named 'layout.html' was added to the directory 'docs/_templates' with the black ribbon.
  - A new option 'html_show_sourcelink = False' was included in the sphinx config file 'docs/conf.py'

## Status
- [x] Ready to go