### PR TITLE
Removing UIBCDF_stdlib from dependencies

### DIFF
--- a/openpharmacophore/_private_tools/colors.py
+++ b/openpharmacophore/_private_tools/colors.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""Module with methods to work with color codes and palettes
+
+Set of tools to work with color codes.
+
+Notes
+-----
+    Most of the methods in this module are nothing but a wrapper of a method or a combination of
+    methods belonging to the module `colors` of the library MatPlotLib.
+
+.. _matplotlib colors api:
+   https://matplotlib.org/stable/api/colors_api.html
+
+"""
+
+from matplotlib import colors as plt_colors
+import numpy as np
+
+def rgb2hex(color):
+
+    """Method to convert a normalized RGB color code to HEX color code
+
+    Conversion of a normalized RGB color (a list of three float numbers between 0.0 and 1.0) to HEX
+    color code. This method is nothing but a wrapper of the tool `matplotlib.colors.to_hex` with the
+    input argument 'keep_apha=False'.
+
+    Parameters
+    ----------
+    color: :obj:`list` of :obj:`float`
+        Normalized RGB color code (three float numbers between 0.0 and 1.0)
+
+    Returns
+    -------
+    str
+        HEX color code with the form "#RRGGBB"
+
+    Examples
+    --------
+
+    >>> from uibcdf_stdlib.colors import rgb2hex
+    >>> rgb2hex([0.0, 0.5, 0.5])
+    '#008080'
+
+    """
+
+    return plt_colors.to_hex(color, keep_alpha=False)
+
+def hex2rgb(color):
+
+    """Method to convert an HEX color code to normalized RGB color code
+
+    Conversion of an HEX color code to normalized RGB color code (a list of three float numbers
+    between 0.0 and 1.0). This method is nothing but a wrapper of the tool
+    `matplotlib.colors.to_rgb`.
+
+    Parameters
+    ----------
+    color: str
+        HEX color code
+
+    Returns
+    -------
+    :obj:`list` of :obj:`float`
+        Normalized RGB color code (three float numbers between 0.0 and 1.0)
+
+    Examples
+    --------
+
+    >>> from uibcdf_stdlib.colors import hex2rgb
+    >>> hex2rgb('#008080')
+    (0.0, 0.5019607843137255, 0.5019607843137255)
+
+    """
+
+    return plt_colors.to_rgb(color)
+
+def is_hex(color):
+
+    """ Method to check if a color code is hexadecimal (HEX)
+
+    This method returns the value True if the input argument corresponds to an hexadecimal color
+    code.
+
+    Parameters
+    ----------
+    color: :obj:
+        Color code
+
+    Returns
+    -------
+    bool
+        True if the input color code takes the hexadecimal (HEX) form.
+
+    Examples
+    --------
+
+    >>> from uibcdf_stdlib.colors import is_hex
+    >>> is_hex('#008080')
+    True
+    >>> is_hex([0.0, 0.5, 0.5])
+    False
+
+    """
+
+    output = False
+
+    if type(color)==str:
+        if (len(color)==6) or (len(color)==7 and color.startswith('#')):
+            output = True
+
+    return output
+
+def is_rgb(color):
+
+    """ Method to check if a color code is normalized decimal RGB.
+
+    This method returns the value True if the input argument corresponds to a normalized decimal
+    RGB color code (three float numbers in a list or tuple with values between 0.0 and 1.0).
+
+    Parameters
+    ----------
+    color: :obj:
+        Color code
+
+    Returns
+    -------
+    bool
+        True if the input color code takes the normalized decimal RGB form.
+
+    Examples
+    --------
+
+    >>> from uibcdf_stdlib.colors import is_rgb
+    >>> is_rgb('#008080')
+    False
+    >>> is_rgb([0.0, 0.5, 0.5])
+    True
+
+    """
+
+    output = False
+
+    if type(color) in [tuple, list, np.ndarray]:
+        if np.shape(color)==(3,):
+            if np.all([type(ii) in [float, int] for ii in color]):
+                output = True
+
+    return output
+
+def convert(color, to_form=None):
+
+    """ Conversion method between different formats of color codes
+
+    This method converts color codes between different formats: normalized decimal RGB and
+    hexadecimal HEX, at the moment.
+
+    Parameters
+    ----------
+    color: :obj:
+        Color code
+    to_form: str
+        Format of the output color code: 'rgb' or 'hex'.
+
+    Returns
+    -------
+    :obj:
+        Color code taking the format specified by the input argument `to_form`.
+
+    Examples
+    --------
+
+    >>> from uibcdf_stdlib.colors import convert
+    >>> convert('#008080', to_form='rgb')
+    (0.0, 0.5019607843137255, 0.5019607843137255)
+    >>> convert('#008080', to_form='hex')
+    '#008080'
+
+    """
+
+    output = None
+
+    if to_form=='rgb':
+        if is_rgb(color):
+            output = color
+        elif is_hex(color):
+            output = hex2rgb(color)
+        else:
+            raise NotImplementedError("This color format was not implemented yet")
+    elif to_form=='hex':
+        if is_rgb(color):
+            output = rgb2hex(color)
+        elif is_hex(color):
+            output = color
+        else:
+            raise NotImplementedError("This color format was not implemented yet")
+
+    return output
+

--- a/openpharmacophore/_private_tools/exceptions.py
+++ b/openpharmacophore/_private_tools/exceptions.py
@@ -75,3 +75,30 @@ class OpenPharmacophoreIOError(IOError):
         if documentation_web is not None:
             message += f" Check the online documentation for more information {documentation_web}"
         super().__init__(self.message)
+
+############# To be removed #########################
+
+class NotImplementedError(NotImplementedError):
+
+    def __init__(self, message=None, issues_web=None):
+
+        if message is None:
+            if issues_web is not None:
+                message = ('It has not been implemeted yet. Write a new issue in'
+                '{} asking for it.'.format(issues_web))
+
+        super().__init__(message)
+
+class InputArgumentError(NotImplementedError):
+
+    def __init__(self, argument, method, documentation_web=None):
+
+        message = ('Invalid value for input argument "{}" in method or class "{}".'
+                'Check the online documentation for more information.'.format(argument, method))
+
+        if documentation_web is not None:
+            message = message[:-1] + ': {}'.format(documentation_web)
+
+        super().__init__(message)
+
+

--- a/openpharmacophore/_private_tools/input_arguments.py
+++ b/openpharmacophore/_private_tools/input_arguments.py
@@ -1,0 +1,56 @@
+import pyunitwizard as puw
+import numpy as np
+from .lists_and_tuples import is_list_or_tuple
+
+def check_input_argument(argument, argument_type, shape=None, dtype_name=None, dimensionality=None,
+                         value_type=None, unit=None):
+
+    if not is_list_or_tuple(argument_type):
+        argument_type = [argument_type]
+
+    if not is_list_or_tuple(value_type):
+        value_type = [value_type]
+
+    output=False
+
+    for aux_argument_type in argument_type:
+        if aux_argument_type is 'ndarray':
+            aux_argument_type=np.ndarray
+        for aux_value_type in value_type:
+            aux_output = _check_single_input_argument(argument, aux_argument_type, shape=shape,
+                    dtype_name=dtype_name, dimensionality=dimensionality, value_type=aux_value_type, unit=unit)
+            if aux_output:
+                output=True
+                break
+        if aux_output:
+            output=True
+            break
+
+    return output
+
+def _check_single_input_argument(argument, argument_type, shape=None, dtype_name=None,
+                                 dimensionality=None, value_type=None, unit=None):
+
+    if argument_type is 'quantity':
+
+        output = puw.check(argument, dimensionality=dimensionality, value_type=value_type,
+                           shape=shape, dtype_name=dtype_name, unit=unit)
+
+    else:
+
+        output = (type(argument)==argument_type)
+
+        if output:
+            if shape is not None:
+                output = (np.shape(argument)==tuple(shape))
+
+        if output:
+            if dtype_name is not None:
+                try:
+                    aux_dtype_name=argument.dtype.name
+                    output = (aux_dtype_name==dtype_name)
+                except:
+                    output = False
+
+    return output
+

--- a/openpharmacophore/color_palettes.py
+++ b/openpharmacophore/color_palettes.py
@@ -1,4 +1,4 @@
-from uibcdf_stdlib.exceptions import InputArgumentError
+from ._private_tools.exceptions import InputArgumentError
 from matplotlib.colors import to_rgb
 """Module with objects and methods to choose and define the color code to represent pharmacophoric
 features when a pharmacophore is shown.

--- a/openpharmacophore/pharmacophoric_point.py
+++ b/openpharmacophore/pharmacophoric_point.py
@@ -3,9 +3,9 @@ from openpharmacophore import __documentation_web__
 from openpharmacophore.color_palettes import get_color_from_palette_for_feature
 from openpharmacophore._private_tools.exceptions import PointWithNoColorError
 # Third Party
-from uibcdf_stdlib.colors import convert as convert_color_code
-from uibcdf_stdlib.input_arguments import check_input_argument
-from uibcdf_stdlib.exceptions import InputArgumentError
+from openpharmacophore._private_toolscolors import convert as convert_color_code
+from openpharmacophore._private_tools.input_arguments import check_input_argument
+from openpharmacophore._private_tools.exceptions import InputArgumentError
 import numpy as np
 import pyunitwizard as puw
 


### PR DESCRIPTION
## Description
Some auxiliary methods were added to the dir _private_tools to avoid importing UIBCDF_stdlib.

## Todos
The auxiliary methods need to be reviewed or removed in the future:
- File colors.py
- File input_arguments.py
- Two exceptions (commented in the exceptions.py file)
