### PR TITLE
chembl_webresource_client from the UIBCDF channel

### DIFF
--- a/devtools/conda-build/meta.yaml
+++ b/devtools/conda-build/meta.yaml
@@ -22,6 +22,8 @@ requirements:
   - requests
   - scikit-learn
   - tqdm
+  - pip:
+    - chembl_webresource_client==0.10.7
 about:
   home: https://uibcdf.org
   license: MIT License

--- a/devtools/conda-build/meta.yaml
+++ b/devtools/conda-build/meta.yaml
@@ -22,8 +22,7 @@ requirements:
   - requests
   - scikit-learn
   - tqdm
-  - pip:
-    - chembl_webresource_client==0.10.7
+  - chembl_webresource_client
 about:
   home: https://uibcdf.org
   license: MIT License

--- a/devtools/conda-envs/development_env.yaml
+++ b/devtools/conda-envs/development_env.yaml
@@ -16,6 +16,8 @@ dependencies:
 - requests
 - scikit-learn
 - tqdm
+- pip:
+  - chembl_webresource_client==0.10.7
 - pytest
 - pip
 - pytest-cov

--- a/devtools/conda-envs/development_env.yaml
+++ b/devtools/conda-envs/development_env.yaml
@@ -16,8 +16,7 @@ dependencies:
 - requests
 - scikit-learn
 - tqdm
-- pip:
-  - chembl_webresource_client==0.10.7
+- chembl_webresource_client
 - pytest
 - pip
 - pytest-cov

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -16,6 +16,8 @@ dependencies:
 - requests
 - scikit-learn
 - tqdm
+- pip:
+  - chembl_webresource_client==0.10.7
 - sphinx
 - sphinx_rtd_theme
 - sphinxcontrib-bibtex

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -16,8 +16,7 @@ dependencies:
 - requests
 - scikit-learn
 - tqdm
-- pip:
-  - chembl_webresource_client==0.10.7
+- chembl_webresource_client
 - sphinx
 - sphinx_rtd_theme
 - sphinxcontrib-bibtex

--- a/devtools/conda-envs/production_env.yaml
+++ b/devtools/conda-envs/production_env.yaml
@@ -16,3 +16,5 @@ dependencies:
 - requests
 - scikit-learn
 - tqdm
+- pip:
+  - chembl_webresource_client==0.10.7

--- a/devtools/conda-envs/production_env.yaml
+++ b/devtools/conda-envs/production_env.yaml
@@ -16,5 +16,4 @@ dependencies:
 - requests
 - scikit-learn
 - tqdm
-- pip:
-  - chembl_webresource_client==0.10.7
+- chembl_webresource_client

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -16,6 +16,8 @@ dependencies:
 - requests
 - scikit-learn
 - tqdm
+- pip:
+  - chembl_webresource_client==0.10.7
 - pytest
 - pip
 - pytest-cov

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -16,8 +16,7 @@ dependencies:
 - requests
 - scikit-learn
 - tqdm
-- pip:
-  - chembl_webresource_client==0.10.7
+- chembl_webresource_client
 - pytest
 - pip
 - pytest-cov

--- a/devtools/requirements.yaml
+++ b/devtools/requirements.yaml
@@ -25,8 +25,7 @@ production:
     - requests
     - scikit-learn
     - tqdm
-    - pip:
-      - chembl_webresource_client==0.10.7
+    - chembl_webresource_client
 
 
 test:


### PR DESCRIPTION
## Description
`chembl_webresource_client 0.10.7` was uploaded to the UIBCDF anaconda channel.
This way we sort of bypass the problem with conda-build and pip.


## Status
- [x] CI tests passed
- [x] Ready to go