### PR TITLE
Protein-ligand chemical features

### DIFF
--- a/openpharmacophore/pharmacophore/pl_interactions.py
+++ b/openpharmacophore/pharmacophore/pl_interactions.py
@@ -1,0 +1,203 @@
+# Protein ligand interactions
+import numpy as np
+from collections import defaultdict
+from rdkit import Chem
+
+
+BS_DIST = 0.85  # in nanometers
+chain_names = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"]
+
+
+smarts_patterns = {
+    '*([CH3X4,CH2X3,CH1X2,F,Cl,Br,I])([CH3X4,CH2X3,CH1X2,F,Cl,Br,I])[CH3X4,CH2X3,CH1X2,F,Cl,Br,I]': 'Hydrophobe',
+    'N=[CX3](N)-N': 'PosIonizable',
+    '[#16!H0]': 'Donor',
+    '[#7!H0&!$(N-[SX4](=O)(=O)[CX4](F)(F)F)]': 'Donor',
+    '[#7&!$([nX3])&!$([NX3]-*=[!#6])&!$([NX3]-[a])&!$([NX4])&!$(N=C([C,N])N)]': 'Acceptor',
+    '[#8!H0&!$([OH][C,S,P]=O)]': 'Donor',
+    '[$(*([CH3X4,CH2X3,CH1X2,F,Cl,Br,I])[CH3X4,CH2X3,CH1X2,F,Cl,Br,I])&!$(*([CH3X4,CH2X3,CH1X2,F,Cl,Br,I])([CH3X4,'
+    'CH2X3,CH1X2,F,Cl,Br,I])[CH3X4,CH2X3,CH1X2,F,Cl,Br,I])]([CH3X4,CH2X3,CH1X2,F,Cl,Br,I])[CH3X4,CH2X3,CH1X2,F,Cl,Br,'
+    'I]': 'Hydrophobe',
+    '[$([+,+2,+3])&!$(*[-,-2,-3])]': 'PosIonizable',
+    '[$([-,-2,-3])&!$(*[+,+2,+3])]': 'NegIonizable',
+    '[$([CH2X4,CH1X3,CH0X2]~[$([!#1]);!$([CH2X4,CH1X3,CH0X2])])]~[CH2X4,CH1X3,CH0X2]~[CH2X4,CH1X3,CH0X2]': 'Hydrophobe',
+    '[$([CH2X4,CH1X3,CH0X2]~[CH2X4,CH1X3,CH0X2]~[$([CH2X4,CH1X3,CH0X2]~[$([!#1]);!$([CH2X4,CH1X3,CH0X2])])])]~[CH2X4,'
+    'CH1X3,CH0X2]~[CH2X4,CH1X3,CH0X2]~[CH2X4,CH1X3,CH0X2]': 'Hydrophobe',
+    '[$([CH3X4,CH2X3,CH1X2,F,Cl,Br,I])&!$(**[CH3X4,CH2X3,CH1X2,F,Cl,Br,I])]': 'Hydrophobe',
+    '[$([CX3,SX3,PX3](=O)[O-,OH])](=O)[O-,OH]': 'NegIonizable',
+    '[$([CX3](=N)(-N)[!N])](=N)-N': 'PosIonizable',
+    '[$([NX3]([CX4])([CX4,#1])[CX4,#1])&!$([NX3]-*=[!#6])]': 'PosIonizable',
+    '[$([O])&!$([OX2](C)C=O)&!$(*(~a)~a)]': 'Acceptor',
+    '[$([SX4,PX4](=O)(=O)[O-,OH])](=O)(=O)[O-,OH]': 'NegIonizable',
+    '[$([S]~[#6])&!$(S~[!#6])]': 'Hydrophobe',
+    '[C&r3]1~[C&r3]~[C&r3]1': 'Hydrophobe',
+    '[C&r4]1~[C&r4]~[C&r4]~[C&r4]1': 'Hydrophobe',
+    '[C&r5]1~[C&r5]~[C&r5]~[C&r5]~[C&r5]1': 'Hydrophobe',
+    '[C&r6]1~[C&r6]~[C&r6]~[C&r6]~[C&r6]~[C&r6]1': 'Hydrophobe',
+    '[C&r7]1~[C&r7]~[C&r7]~[C&r7]~[C&r7]~[C&r7]~[C&r7]1': 'Hydrophobe',
+    '[C&r8]1~[C&r8]~[C&r8]~[C&r8]~[C&r8]~[C&r8]~[C&r8]~[C&r8]1': 'Hydrophobe',
+    '[CH2X4,CH1X3,CH0X2]~[CH3X4,CH2X3,CH1X2,F,Cl,Br,I]': 'Hydrophobe',
+    'a1aaaa1': 'Aromatic',
+    'a1aaaaa1': 'Aromatic',
+    'c1nn[nH1]n1': 'NegIonizable'}
+
+
+def is_ligand_atom(atom):
+    """ Check if an atom belongs to a ligand. """
+    if not atom.residue.is_water and not atom.residue.is_protein\
+            and atom.residue.n_atoms > 4:
+        return True
+    return False
+
+
+def find_ligands_in_traj(traj):
+    """ Returns a list of ligand ids in a trajectory.
+
+        Parameters
+        ----------
+        traj : mdtraj.Trajectory
+
+        Returns
+        -------
+        ligands : list[str]
+            A list of the ligands ids in the topology file
+    """
+    topology = traj.topology
+
+    ligands = []
+    for atom in topology.atoms:
+        if is_ligand_atom(atom):
+            chain = atom.residue.chain.index
+            ligand_id = atom.residue.name + ":" + chain_names[chain]
+            if ligand_id not in ligands:
+                ligands.append(ligand_id)
+
+    return ligands
+
+
+def get_ligand_atom_indices(traj, ligand_id):
+    """ Returns the indices of the atoms of the ligand with the given id
+        in the trajectory
+
+        Parameters
+        ----------
+        traj : mdtraj.Trajectory
+
+        ligand_id : str
+
+        Returns
+        -------
+        indices : list[int]
+
+    """
+    topology = traj.topology
+    indices = []
+
+    ligand, chain = ligand_id.split(":")
+    chain_index = chain_names.index(chain)
+    for atom in topology.atoms:
+        if atom.residue.name == ligand and atom.residue.chain.index == chain_index:
+            indices.append(atom.index)
+
+    return indices
+
+
+def ligand_centroid(traj, ligand_id):
+    """ Get the centroid of the ligand with the given id."""
+    indices = get_ligand_atom_indices(traj, ligand_id)
+    coords = traj.xyz[:, indices, :]
+    return np.mean(coords, axis=1)[0]
+
+
+def maximum_distance(centroid, coordinates):
+    """ Get the maximum distance from the centroid to the given
+        coordinates
+    """
+    distance = np.sqrt(np.sum(np.power(coordinates - centroid, 2), axis=1))
+    return np.amax(distance)
+
+
+def ligand_maximum_extent(traj, ligand_id):
+    """ Computes the maximum extent of the ligand. This is the maximum distance
+        from the centroid to any of its atoms.
+    """
+    centroid = ligand_centroid(traj, ligand_id)
+    indices = get_ligand_atom_indices(traj, ligand_id)
+    coords = traj.xyz[:, indices, :][0]
+    return maximum_distance(centroid, coords)
+
+
+def get_binding_site_atoms_indices(lig_center, lig_max_extent, coords):
+    """ Get the indices of all the atoms that belong to the binding site.
+
+        Parameters
+        ----------
+        lig_center : np.ndarray of shape (3,)
+        lig_max_extent : float
+        coords: np.ndarray of shape(n_atoms, 3)
+
+        Returns
+        -------
+        bs_indices: np.ndarray
+    """
+    bs_cutoff = lig_max_extent + BS_DIST
+    distance = np.sqrt(np.sum(np.power(coords - lig_center, 2), axis=1))
+    return np.where(np.logical_and(distance > lig_max_extent, distance <= bs_cutoff))[0]
+
+
+def chemical_features(molecule, bs_indices=None):
+    """ Find chemical features in a molecule using smarts patterns
+
+        Parameters
+        ----------
+        molecule : rdkit.Mol
+
+        bs_indices: np.ndarray, optional
+
+        Returns
+        -------
+        features dict[str, list[tuple[int]]
+
+
+    """
+    features = defaultdict(list)
+
+    for smarts, feat_name in smarts_patterns.items():
+        pattern = Chem.MolFromSmarts(smarts)
+        atom_indices = molecule.GetSubstructMatches(pattern)
+        if len(atom_indices) > 0:
+            for indices in atom_indices:
+                skip = False
+                if bs_indices is not None:
+                    for index in indices:
+                        if index not in bs_indices:
+                            skip = True
+                            break
+                if not skip:
+                    features[feat_name].append(indices)
+
+    return features
+
+
+def features_centroid(features, coords):
+    """ Compute the centroid of the chemical features.
+
+        Parameters
+        ----------
+        features : dict[str, list[tuple[int]]]
+
+        coords : np.ndarray
+
+        Returns
+        -------
+        centroids : dict[str, list[np.array]]
+
+    """
+    centroids = defaultdict(list)
+    for feat, all_indices in features.items():
+        for indices in all_indices:
+            feat_coords = coords[0, indices, :]
+            feat_center = np.mean(feat_coords, axis=0)
+            centroids[feat].append(feat_center)
+
+    return centroids

--- a/tests/pharmacophore/test_pl_interactions.py
+++ b/tests/pharmacophore/test_pl_interactions.py
@@ -1,0 +1,180 @@
+import openpharmacophore.pharmacophore.pl_interactions as pli
+import openpharmacophore.data as data
+import numpy as np
+import pytest
+import mdtraj as mdt
+
+
+@pytest.fixture
+def trajectory():
+    return mdt.load(data.pdb["1qku"])
+
+
+def test_find_ligands(trajectory):
+    ligands = pli.find_ligands_in_traj(trajectory)
+    assert len(ligands) == 3
+    assert ligands == [
+        "EST:D",
+        "EST:E",
+        "EST:F",
+    ]
+
+
+def test_get_ligand_atom_indices(trajectory):
+    traj = trajectory
+    ligand_indices = pli.get_ligand_atom_indices(traj, "EST:D")
+    expected_indices = list(range(5940, 5960))
+    assert ligand_indices == expected_indices
+
+
+def test_ligand_centroid(trajectory):
+    traj = trajectory
+    ligand_id = "EST:D"
+    centroid = pli.ligand_centroid(traj, ligand_id)
+
+    coordinates = np.array(
+        [[[10.4106, 1.7203, 2.4775],
+          [10.2995, 1.7834, 2.537],
+          [10.1695, 1.7355, 2.512],
+          [10.0598, 1.799, 2.5704],
+          [10.1506, 1.624, 2.4274],
+          [10.2621, 1.5588, 2.366],
+          [10.2371, 1.4379, 2.2735],
+          [10.3644, 1.3753, 2.2086],
+          [10.4898, 1.3873, 2.2953],
+          [10.5178, 1.5388, 2.3261],
+          [10.3957, 1.6078, 2.3918],
+          [10.6462, 1.5459, 2.4125],
+          [10.7711, 1.4803, 2.3508],
+          [10.7463, 1.3343, 2.3124],
+          [10.617, 1.327, 2.2242],
+          [10.6228, 1.1821, 2.1792],
+          [10.7701, 1.1713, 2.1263],
+          [10.8494, 1.2719, 2.2135],
+          [10.961, 1.2027, 2.2746],
+          [10.7379, 1.2449, 2.4419]]],
+        dtype=np.float32)
+    expected_centroid = np.mean(coordinates, axis=1)[0]
+    assert centroid.shape == (3, )
+    assert np.allclose(centroid, expected_centroid)
+
+
+def test_maximum_distance():
+    centroid = np.array([0., 0., 0.])
+    coordinates = np.array([
+        [1., 1., 1.],
+        [2., 2., 2.],
+        [3., 3., 3.],
+        [4., 4., 4.],
+    ])
+    assert pli.maximum_distance(centroid, coordinates) == np.sqrt(48)
+
+
+def test_maximum_ligand_extent(trajectory):
+    assert np.allclose(pli.ligand_maximum_extent(trajectory, "EST:D"), 0.59849)
+
+
+def test_get_binding_site_atoms_indices():
+    ligand_maximum_extent = 0.15
+    ligand_centroid = np.array([0.0, 0.0, 0.0])
+    coordinates = np.array([
+        [0.01, 0.01, 0.01],
+        [0.02, 0.02, 0.02],
+        [0.3, 0.3, 0.3],
+        [0.4, 0.4, 0.4],
+        [0.5, 0.5, 0.5],
+        [1., 1., 1.],
+        [2., 2., 2.],
+    ])
+    bsite_indices = pli.get_binding_site_atoms_indices(
+        ligand_centroid, ligand_maximum_extent, coordinates)
+    assert isinstance(bsite_indices, np.ndarray)
+
+    expected_indices = np.array([2, 3, 4])
+    assert np.all(bsite_indices == expected_indices)
+
+
+@pytest.fixture()
+def smart_patterns_mock():
+    return {
+        'N=[CX3](N)-N': 'PosIonizable',
+        '[#16!H0]': 'Donor',
+        '[$([O])&!$([OX2](C)C=O)&!$(*(~a)~a)]': 'Acceptor',
+        '[C&r3]1~[C&r3]~[C&r3]1': 'Hydrophobe',
+        'a1aaaa1': 'Aromatic',
+        'c1nn[nH1]n1': 'NegIonizable'}
+
+
+side_effect = [
+        ((0, 1), (1, 2)),
+        ((2, 3), ),
+        ((3, 4), (5, 6)),
+        ((7, 8, 9),),
+        ((10, 11, 12), (13, 14, 15)),
+        (),
+    ]
+
+
+def test_ligand_chemical_features(mocker, smart_patterns_mock):
+    mocker.patch.dict(
+        pli.smarts_patterns,
+        smart_patterns_mock,
+        clear=True
+    )
+    mock_mol = mocker.Mock()
+    mock_mol.GetSubstructMatches.side_effect = side_effect
+    features = pli.chemical_features(mock_mol, None)
+    expected_features = {
+        'PosIonizable': [(0, 1), (1, 2)],
+        'Donor': [(2, 3)],
+        'Acceptor': [(3, 4), (5, 6)],
+        'Hydrophobe': [(7, 8, 9)],
+        'Aromatic': [(10, 11, 12), (13, 14, 15)]
+    }
+    assert features == expected_features
+
+
+def test_binding_site_chemical_features(mocker, smart_patterns_mock):
+    mocker.patch.dict(
+        pli.smarts_patterns,
+        smart_patterns_mock,
+        clear=True
+    )
+    mock_mol = mocker.Mock()
+    mock_mol.GetSubstructMatches.side_effect = side_effect
+    bs_indices = np.array([5, 6, 7, 8, 9, 10, 11, 12])
+    features = pli.chemical_features(mock_mol, bs_indices)
+    expected_features = {
+        "Acceptor": [(5, 6)],
+        'Hydrophobe': [(7, 8, 9)],
+        'Aromatic': [(10, 11, 12)]
+    }
+    assert features == expected_features
+
+
+def test_features_centroid():
+    coords = np.array([[
+        [1., 1., 1.],
+        [2., 2., 2.],
+        [3., 3., 3.],
+        [4., 4., 4.],
+        [5., 5., 5.],
+        [6., 6., 6.],
+    ]])
+    assert coords.shape == (1, 6, 3)
+    features = {
+        "Acceptor": [(1,)],
+        "Hydrophobe": [(2, 3), (4,)]
+    }
+    expected_feats_centroid = {
+        "Acceptor": [np.array([2., 2., 2.])],
+        "Hydrophobe": [np.array([3.5, 3.5, 3.5]),
+                       np.array([5., 5., 5.])]
+    }
+    feat_centroid = pli.features_centroid(features, coords)
+    assert len(feat_centroid) == 2
+    assert feat_centroid["Acceptor"][0].shape == (3,)
+    assert feat_centroid["Hydrophobe"][0].shape == (3,)
+    assert np.all(feat_centroid["Acceptor"][0] == expected_feats_centroid["Acceptor"][0])
+    assert np.all(feat_centroid["Hydrophobe"][0] == expected_feats_centroid["Hydrophobe"][0])
+    assert np.all(feat_centroid["Hydrophobe"][1] == expected_feats_centroid["Hydrophobe"][1])


### PR DESCRIPTION
## Description
To compute pharmacophoric points for protein-ligand complexes, their interactions must be computed first. 
The following is a first attempt to do so. Right now, we can find the ligands in the protein, the binding site atoms and the chemical features in both.
 
