### PR TITLE
Fixing ligand bond orders

### DIFF
--- a/openpharmacophore/io/json_file.py
+++ b/openpharmacophore/io/json_file.py
@@ -94,8 +94,8 @@ def json_pharmacophoric_elements(pharmacophoric_points):
 
         Parameters
         ----------
-        pharmacophoric_points : list[PharmacophoricPoint]
-            Pharmacophore points that will be used to construct the dictionary
+        pharmacophoric_points : Pharmacophore
+            Pharmacophoric points that will be used to construct the dictionary
 
         Returns
         -------

--- a/openpharmacophore/pharmacophore/ligand_based/rdp.py
+++ b/openpharmacophore/pharmacophore/ligand_based/rdp.py
@@ -634,5 +634,5 @@ def find_common_pharmacophores(mols, chem_feats, n_points,
                 top_queue.append(top_representative)
 
     pharmacophores = [t.to_pharmacophore(ligands[t.id[0]]) for t in top_queue]
-    pharmacophores.sort(key=lambda p: p.score)
+    pharmacophores.sort(key=lambda p: p.score, reverse=True)
     return pharmacophores

--- a/openpharmacophore/pharmacophore/ligand_receptor/pl_complex.py
+++ b/openpharmacophore/pharmacophore/ligand_receptor/pl_complex.py
@@ -290,9 +290,13 @@ class PLComplex:
 
         template = Chem.MolFromSmiles(smiles)
         if self._ligand.GetNumAtoms() != template.GetNumAtoms():
-            raise exc.DifferentNumAtomsError(
-                self._ligand.GetNumAtoms(), template.GetNumAtoms()
-            )
+            # Removing Hs involved in double bonds can help with the
+            # matching
+            template = Chem.RemoveAllHs(template)
+            if self._ligand.GetNumAtoms() != template.GetNumAtoms():
+                raise exc.DifferentNumAtomsError(
+                    self._ligand.GetNumAtoms(), template.GetNumAtoms()
+                )
 
         fixed_lig = Chem.AssignBondOrdersFromTemplate(template, self._ligand)
         if add_hydrogens:
@@ -737,10 +741,11 @@ class PLComplex:
         for ii in indices:
             res = self.topology.atom(ii).residue
             if res.name != "HOH":
-                residues.add(self.topology.atom(ii).residue.index)
+                residues.add(res.index)
 
-        # Add only whole residues
+        residues = sorted(residues)
         atom_ind = []
+        # Add only whole residues
         for ii in residues:
             for atom in self.topology.residue(ii).atoms:
                 atom_ind.append(atom.index)


### PR DESCRIPTION
## Description
Updated `fix_ligand` function in `PLComplex` so it removes hydrogens from the template molecule. This makes possible to fix ligands that couldn't be fixed previously.

## Status
- [ ] Ready to go