### PR TITLE
Fixed errors in documentation examples

### DIFF
--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -32,3 +32,11 @@ dependencies:
 - nbconvert-core=6.5.0
 - nbconvert-pandoc=6.5.0
 - nbformat=5.4.0
+# Ipython and widgets for documentation notebooks. Avoid
+# error when importing nglview
+- ipython=7.33.0
+- ipython_genutils=0.2.0
+- ipywidgets=7.7.0
+- jupyterlab_widgets=1.1.0
+- widgetsnbextension=3.6.0
+

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -15,6 +15,7 @@ dependencies:
 - rdkit=2022.03.3
 - requests=2.28.0
 - tqdm=4.64.0
+# Tests
 - pytest=7.1.2
 - pytest-mock=3.8.2
 - pip

--- a/docs/contents/examples/dynamic-pharmacophore/er_alpha_md.ipynb
+++ b/docs/contents/examples/dynamic-pharmacophore/er_alpha_md.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "e6febb66-6211-4006-918a-f64e7e106dae",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/contents/examples/ligand-based/ligand_preparation.ipynb
+++ b/docs/contents/examples/ligand-based/ligand_preparation.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "78ee3d59-94bf-4dcc-8a50-01aced22fbde",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/contents/examples/ligand-based/thrombin.ipynb
+++ b/docs/contents/examples/ligand-based/thrombin.ipynb
@@ -14,7 +14,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/contents/examples/ligand-receptor/er-alpha.ipynb
+++ b/docs/contents/examples/ligand-receptor/er-alpha.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "37cca21d-9b42-46c0-ac48-6e77963b68ab",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/contents/examples/ligand-receptor/hrv.ipynb
+++ b/docs/contents/examples/ligand-receptor/hrv.ipynb
@@ -12,7 +12,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "154aaaf7-6016-444f-941a-9c40cbeff4c0",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/contents/examples/other/binding-site/complex_binding_site.ipynb
+++ b/docs/contents/examples/other/binding-site/complex_binding_site.ipynb
@@ -17,7 +17,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "3e989c61-d59b-429d-8fbe-c971396e2026",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/contents/examples/other/pl-interactions/aromatic_interactions.ipynb
+++ b/docs/contents/examples/other/pl-interactions/aromatic_interactions.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "6741d976-79df-4c53-81ff-14a709f740a8",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/contents/examples/other/pl-interactions/hydrogen_bonding.ipynb
+++ b/docs/contents/examples/other/pl-interactions/hydrogen_bonding.ipynb
@@ -14,7 +14,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "b7fc0b52-b132-4922-9000-818b7c80ab67",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/contents/examples/other/pl-interactions/hydrophobic_interactions.ipynb
+++ b/docs/contents/examples/other/pl-interactions/hydrophobic_interactions.ipynb
@@ -12,7 +12,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "c45b0ee5-0eae-49b4-b914-a1657b783a92",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/contents/examples/virtual-screening/screening.ipynb
+++ b/docs/contents/examples/virtual-screening/screening.ipynb
@@ -12,7 +12,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "e5740f66-ff59-4eca-b38e-de1984a0a5bc",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/openpharmacophore/visualization/view.py
+++ b/openpharmacophore/visualization/view.py
@@ -209,9 +209,8 @@ class Viewer:
 
             Parameters
             ----------
-            struct : int, optional
-                Frame, structure or conformer index to show if there are any proteins,
-                ligands or pharmacophores with multiple structures.
+            src : str
+                Path to the html file.
 
             Returns
             -------


### PR DESCRIPTION
## Description
The notebooks of the documentation are showing the following error in the first cell:

```python
AttributeError: 'super' object has no attribute '_ipython_display_'
```
This is caused by a mismatch between nglview and ipython versions. To fix this, the documentation conda
environment was updated with specific versions.
